### PR TITLE
Fix excessive flash wait states

### DIFF
--- a/Libraries/CMSIS/HK32F030M/Source/system_hk32f030m.c
+++ b/Libraries/CMSIS/HK32F030M/Source/system_hk32f030m.c
@@ -230,7 +230,7 @@ static void SetSysClockToHSI_16M(void)
 		/* Flash wait state */
 		ACRreg = FLASH->ACR;
 		ACRreg &= (uint32_t)((uint32_t)~FLASH_ACR_LATENCY);
-		FLASH->ACR = (uint32_t)(FLASH_Latency_1|ACRreg);	
+		FLASH->ACR = (uint32_t)(FLASH_Latency_0|ACRreg);	
 
 		RCCHCLKReg = RCC->CFGR;
 		RCCHCLKReg &= (uint32_t)((uint32_t)~RCC_CFGR_HPRE_Msk);
@@ -289,7 +289,7 @@ static void SetSysClockToHSI_32M(void)
 		/* Flash wait state */
 		ACRreg = FLASH->ACR;
 		ACRreg &= (uint32_t)((uint32_t)~FLASH_ACR_LATENCY);
-		FLASH->ACR = (uint32_t)(FLASH_Latency_2|ACRreg);	
+		FLASH->ACR = (uint32_t)(FLASH_Latency_1|ACRreg);	
 
 
 		RCCHCLKReg = RCC->CFGR;


### PR DESCRIPTION
The Datasheet specifies:
<=16MHz :  0 wait states
<=32MHz : 1 wait states

SetSysClockToHSI*** functions were using excessive values. This MCU doesn't have prefetch at all, so wait states hurt the performance seriously. Interestingly, SetSysClockToEXTCLK is using the correct values. I've tested zero wait states @ 32MHz, but better stick with the official specs.