### PR TITLE
Add eeprom area to linker script, provide example

### DIFF
--- a/Libraries/LDScripts/hk32f030mf4p6.ld
+++ b/Libraries/LDScripts/hk32f030mf4p6.ld
@@ -31,11 +31,19 @@ MEMORY
 {
   RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = 4K
   FLASH (rx)     : ORIGIN = 0x08000000, LENGTH = 16K
+  EEPROM (rx)    : ORIGIN = 0x0C000000, LENGTH = 448
 }
 
 /* Define output sections */
 SECTIONS
 {
+  .eeprom :
+  {
+    . = ALIGN(4);
+    KEEP(*(.eeprom))	/* .eeprom section */
+    . = ALIGN(4);
+  } >EEPROM
+  
   /* The startup code goes first into FLASH */
   .isr_vector :
   {


### PR DESCRIPTION
JLink doesn't program that area, but at least variables can be easily located there-

Example:

```
__attribute__((section(".eeprom"))) settings_t settings_ee; // Settings in eeprom
settings_t settings;                                        // Settings in ram

void store_settings(void){
    uint8_t *src = (uint8_t*)&settings;                     // Pointer to ram data
    uint32_t dst = (uint32_t)&settings_ee;                  // Address of eeprom data
    FLASH_Unlock();                                         // Unlock Flash
    for(uint16_t i=0; i<sizeof(settings_t); i++){           // Erase and write each byte
        EEPROM_EraseByte(dst);
        EEPROM_ProgramByte(dst++, *src++);
    }
    FLASH_Lock();                                           // Lock Flash
}
```