### PR TITLE
Cleanup, improvements

### DIFF
--- a/Libraries/CMSIS/HK32F030M/Source/system_hk32f030m.c
+++ b/Libraries/CMSIS/HK32F030M/Source/system_hk32f030m.c
@@ -36,8 +36,6 @@
 #define SYSCLK_SRC_LSI			0x5
 #define SYSCLK_SCR_EXTCLK_IO	0x6
 
-#define SYSCLK_SOURCE	SYSCLK_SRC_HSI32M
-
 // #define VECT_TAB_SRAM
 #define VECT_TAB_OFFSET  0x0 /*!< Vector Table base offset field. This value must be a multiple of 0x200. */
 

--- a/Libraries/CMSIS/HK32F030M/Source/system_hk32f030m.c
+++ b/Libraries/CMSIS/HK32F030M/Source/system_hk32f030m.c
@@ -65,7 +65,7 @@
 
 
 /* Provide a weak function to handle system clock failure*/
-__weak void clockFailure(void){
+__attribute__((weak)) void clockFailure(void){
 	NVIC_SystemReset();     		/* Timeout reached, oscillator not working, reset system */
 }
 

--- a/User/hk32f030m_conf.h
+++ b/User/hk32f030m_conf.h
@@ -18,9 +18,9 @@
  
 //#define SYSCLK_SOURCE SYSCLK_SRC_HSI8M
 //#define SYSCLK_SOURCE SYSCLK_SRC_HSI16M
-#define SYSCLK_SOURCE SYSCLK_SCR_HSI32M
+#define SYSCLK_SOURCE SYSCLK_SRC_HSI32M
 //#define SYSCLK_SOURCE SYSCLK_SRC_LSI
-//#define SYSCLK_SOURCE SYSCLK_SCR_EXTCLK_IO
+//#define SYSCLK_SOURCE SYSCLK_SRC_EXTCLK_IO
 	 
 /* Exported types ------------------------------------------------------------*/
 /* Exported constants --------------------------------------------------------*/

--- a/User/hk32f030m_conf.h
+++ b/User/hk32f030m_conf.h
@@ -14,6 +14,14 @@
  extern "C" {
 #endif
 
+/* System clock selection  */
+ 
+//#define SYSCLK_SOURCE SYSCLK_SRC_HSI8M
+//#define SYSCLK_SOURCE SYSCLK_SRC_HSI16M
+#define SYSCLK_SOURCE SYSCLK_SCR_HSI32M
+//#define SYSCLK_SOURCE SYSCLK_SRC_LSI
+//#define SYSCLK_SOURCE SYSCLK_SCR_EXTCLK_IO
+	 
 /* Exported types ------------------------------------------------------------*/
 /* Exported constants --------------------------------------------------------*/
 


### PR DESCRIPTION
Remove excessive checks.
Create general clock failure callback declared as weak, so the user can override it.
Move system clock selection to hk32f030m_conf.f